### PR TITLE
fix: remove non-existent format-check job dependency from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -153,7 +153,7 @@ jobs:
   lint-summary:
     name: Lint Summary
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, format-check, security-audit, dependency-check]
+    needs: [lint, typecheck, security-audit, dependency-check]
     if: always()
 
     steps:
@@ -165,13 +165,12 @@ jobs:
         echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
         echo "| Code Linting | ${{ needs.lint.result }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Type Checking | ${{ needs.typecheck.result }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Format Check | ${{ needs.format-check.result }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Security Audit | ${{ needs.security-audit.result }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Dependency Check | ${{ needs.dependency-check.result }} |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
         # Set overall status
-        if [ "${{ needs.lint.result }}" = "success" ] && [ "${{ needs.typecheck.result }}" = "success" ] && [ "${{ needs.format-check.result }}" = "success" ] && [ "${{ needs.security-audit.result }}" = "success" ]; then
+        if [ "${{ needs.lint.result }}" = "success" ] && [ "${{ needs.typecheck.result }}" = "success" ] && [ "${{ needs.security-audit.result }}" = "success" ]; then
           echo "## Overall Status: ✅ PASSED" >> $GITHUB_STEP_SUMMARY
         else
           echo "## Overall Status: ❌ FAILED" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Remove references to non-existent `format-check` job from lint workflow
- Fix workflow error: "Job 'lint-summary' depends on unknown job 'format-check'"
- Clean up summary table and status conditions

## Changes
- Removed `format-check` from `lint-summary` job dependencies
- Removed format check row from summary table output  
- Removed format check condition from overall status check

## Test plan
- [ ] Verify workflow runs without dependency errors
- [ ] Confirm lint summary job executes successfully
- [ ] Check that summary output displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)