### PR TITLE
Bump pprof format version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@platformatic/react-pprof",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@platformatic/react-pprof",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@storybook/react-webpack5": "^9.0.17",
         "gl-matrix": "^3.4.3",
-        "pprof-format": "github:datadog/pprof-format#a1c03e5da852d1f76d149ea1d3fcd660cdb19e4c",
+        "pprof-format": "^2.2.1",
         "protobufjs": "^7.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -348,13 +348,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@datadog/pprof/node_modules/pprof-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.1.0.tgz",
-      "integrity": "sha512-0+G5bHH0RNr8E5hoZo/zJYsL92MhkZjwrHp3O2IxmY8RJL9ooKeuZ8Tm0ZNBw5sGZ9TiM71sthTjWoR2Vf5/xw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@datadog/pprof/node_modules/source-map": {
       "version": "0.7.6",
@@ -5560,9 +5553,9 @@
       "license": "MIT"
     },
     "node_modules/pprof-format": {
-      "version": "2.0.4",
-      "resolved": "git+ssh://git@github.com/datadog/pprof-format.git#a1c03e5da852d1f76d149ea1d3fcd660cdb19e4c",
-      "integrity": "sha512-xLcWx8UcXhzQi/YZDtQaw4rdl9niLQUwsp+ZjqMlPnUvMyGNX9RnKZ31vu4kJOLuvK15KWk42Z+Iuwo2cdp/hA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
+      "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
       "license": "MIT"
     },
     "node_modules/pretty-error": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@storybook/react-webpack5": "^9.0.17",
     "gl-matrix": "^3.4.3",
-    "pprof-format": "github:datadog/pprof-format#a1c03e5da852d1f76d149ea1d3fcd660cdb19e4c",
+    "pprof-format": "^2.2.1",
     "protobufjs": "^7.5.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"


### PR DESCRIPTION
This is necessary for pprof-format to correctly support ESM/CJS dual export.